### PR TITLE
adding vcl_dir as an option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,7 @@ class varnish (
   $varnish_secret_file          = '/etc/varnish/secret',
   $varnish_storage_file         = '/var/lib/varnish-storage/varnish_storage.bin',
   $varnish_ttl                  = '120',
+  $vcl_dir                      = undef,
   $shmlog_dir                   = '/var/lib/varnish',
   $shmlog_tempfs                = true,
   $version                      = present,

--- a/templates/varnish-conf.erb
+++ b/templates/varnish-conf.erb
@@ -97,6 +97,9 @@ DAEMON_OPTS="-a <%= scope.lookupvar('varnish_listen_address') %>:<%= scope.looku
 <% else -%>
              -s <%= scope.lookupvar('storage_type') %>,<%= scope.lookupvar('varnish_storage_file') %>,<%= scope.lookupvar('varnish_storage_size') %> \
 <% end -%>
+<% if scope.lookupvar('vcl_dir') -%>
+             -p vcl_dir=<%= scope.lookupvar('vcl_dir') %> \
+<% end -%>
 <% if scope.lookupvar('varnish::params::version').to_i == 4 -%>
              -u <%= scope.lookupvar('varnish_user') %> \
              -g <%= scope.lookupvar('varnish_group') %> \


### PR DESCRIPTION
Adding vcl_dir option to the varnish configuration file makes it easier to use includes.
